### PR TITLE
Replace deprecated commit_bytes and change repeated trait func 

### DIFF
--- a/tests/sig_and_vrf_example.rs
+++ b/tests/sig_and_vrf_example.rs
@@ -26,13 +26,13 @@ define_proof! {vrf_proof, "VRF", (x), (A, G, H), (B) : A = (x * B), G = (x * H) 
 
 /// Defines how the construction interacts with the transcript.
 trait TranscriptProtocol {
-    fn append_message(&mut self, message: &[u8]);
+    fn append_message_example(&mut self, message: &[u8]);
     fn hash_to_group(self) -> RistrettoPoint;
 }
 
 impl TranscriptProtocol for Transcript {
-    fn append_message(&mut self, message: &[u8]) {
-        self.commit_bytes(b"msg", message);
+    fn append_message_example(&mut self, message: &[u8]) {
+        self.append_message(b"msg", message);
     }
     fn hash_to_group(mut self) -> RistrettoPoint {
         let mut bytes = [0u8; 64];
@@ -84,7 +84,7 @@ impl KeyPair {
     }
 
     fn sign(&self, message: &[u8], sig_transcript: &mut Transcript) -> Signature {
-        sig_transcript.append_message(message);
+        sig_transcript.append_message_example(message);
         let (proof, _points) = sig_proof::prove_batchable(
             sig_transcript,
             sig_proof::ProveAssignments {
@@ -105,7 +105,7 @@ impl KeyPair {
         proof_transcript: &mut Transcript,
     ) -> (VrfOutput, VrfProof) {
         // Use function_transcript to hash the message to a point H
-        function_transcript.append_message(message);
+        function_transcript.append_message_example(message);
         let H = function_transcript.hash_to_group();
 
         // Compute the VRF output G and form a proof
@@ -132,7 +132,7 @@ impl Signature {
         pubkey: &PublicKey,
         sig_transcript: &mut Transcript,
     ) -> Result<(), ()> {
-        sig_transcript.append_message(message);
+        sig_transcript.append_message_example(message);
         sig_proof::verify_batchable(
             &self.0,
             sig_transcript,
@@ -156,7 +156,7 @@ impl VrfOutput {
         proof: &VrfProof,
     ) -> Result<(), ()> {
         // Use function_transcript to hash the message to a point H
-        function_transcript.append_message(message);
+        function_transcript.append_message_example(message);
         let H = function_transcript.hash_to_group().compress();
 
         vrf_proof::verify_compact(


### PR DESCRIPTION
Replace deprecated commit_bytes and change repeated trait func from `append_message` to `append_message_example`.
For rightnow it's not compatible with the `Merlin 1.2.0`, when run `cargo +nightly test`, error occurred:
![image](https://user-images.githubusercontent.com/30716372/65010326-09faa180-d942-11e9-88dd-a3107ce2fc29.png)
