### PR TITLE
Move from failure to thiserror.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,9 @@ features = ["nightly"]
 [dependencies]
 merlin = "2"
 rand = "0.7"
-serde = "1.0"
-serde_derive = "1.0"
-failure = "0.1.5"
-failure_derive = "0.1.5"
+serde = "1"
+serde_derive = "1"
+thiserror = "1"
 curve25519-dalek = { version = "2", features = ["serde"] }
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,11 @@
+use thiserror::Error;
 /// An error during proving or verification, such as a verification failure.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ProofError {
     /// Something is wrong with the proof, causing a verification failure.
-    #[fail(display = "Verification failed.")]
+    #[error("Verification failed.")]
     VerificationFailure,
     /// Occurs during batch verification if the batch parameters are mis-sized.
-    #[fail(display = "Mismatched parameter sizes for batch verification.")]
+    #[error("Mismatched parameter sizes for batch verification.")]
     BatchSizeMismatch,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,6 @@
 //! Docs will only build on nightly Rust until
 //! [RFC 1990 stabilizes](https://github.com/rust-lang/rust/issues/44732).
 
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-
 extern crate serde;
 
 #[doc(hidden)]


### PR DESCRIPTION
This allows having `std::error::Error` types.